### PR TITLE
[troubleshooting] hiera note display typo

### DIFF
--- a/docs/source/troubleshooting/hiera.rst
+++ b/docs/source/troubleshooting/hiera.rst
@@ -96,7 +96,8 @@ Find the value hiera returns to puppet
 
 The latter will show one what hiera returned to puppet.
 
-*Note*: On the previous messaging class exmaple. If one wants to find the rabbit_names value, don't use `hiera rabbit_names -c /etc/puppet/hiera.yaml`, but `hiera cloud::messaging::rabbit_names -c /etc/puppet/hiera.yaml`. cloud::messaging::rabbit_names is your actual parameter name.
+.. note::
+    On the previous messaging class exmaple. If one wants to find the rabbit_names value, don't use ``hiera rabbit_names -c /etc/puppet/hiera.yaml``, but ``hiera cloud::messaging::rabbit_names -c /etc/puppet/hiera.yaml``. ``cloud::messaging::rabbit_names`` is your actual parameter name.
 
 
 Find which files are opened by hiera to look for informations


### PR DESCRIPTION
Fix the display for "note" in "Find the value hiera returns to puppet" doc part. (http://spinal-stack.readthedocs.org/en/latest/troubleshooting/hiera.html#find-the-value-hiera-returns-to-puppet)

```
  *note* -> .. note:: like other note in page http://spinal-stack.readthedocs.org/en/latest/deploy/introduction.html#requirements
  `code` -> ``code`` (Display inline code https://pythonhosted.org/an_example_pypi_project/sphinx.html#code)
```
