### PR TITLE
Add section with security advisories and fixes

### DIFF
--- a/docs/source/advisories/index.rst
+++ b/docs/source/advisories/index.rst
@@ -1,0 +1,9 @@
+Security Advisories
+===================
+
+.. toctree::
+   :maxdepth: 5
+
+   ossa2014041
+
+.. update index

--- a/docs/source/advisories/ossa2014041.rst
+++ b/docs/source/advisories/ossa2014041.rst
@@ -1,0 +1,38 @@
+OSSA-2014-041
+=============
+
+
+Announce: http://lists.openstack.org/pipermail/openstack-announce/2014-December/000317.html
+
+Impacted versions : Every version until Kilo
+Fixable versions: Starting from I-1.3.0
+
+How Spinal Stack prevents it ?
+------------------------------
+
+To prevent OSSA-2014-041 on your deployed platforms, a user needs to set specific policies for Glance API via the glance_api_policies configuration setting in the environment file.
+
+The needed policies are the following :
+
+    'delete_image_location': 'role:admin'
+    'get_image_location': 'role:admin'
+    'set_image_location': 'role:admin'
+
+By default, if the user does not specify any glance_api_policies in his configuration file, those parameters will be added automatically else the user will need to add them manually in addition of the policies she's adding.
+
+Find below the snippet to use ::
+
+    glance_api_policies:
+      delete_image_location:
+        key: delete_image_location
+        value: 'role:admin'
+      get_image_location:
+        key: get_image_location
+        value: 'role:admin'
+      set_image_location:
+        key: set_image_location
+        value: 'role:admin'
+
+To completely disable Glance API policies, set the following in your environment file ::
+
+    glance_api_policies: false

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,7 @@ Tables of contents
    dev/index
    troubleshooting/index
    changelog/index
+   advisories/index
 
 .. update index
 


### PR DESCRIPTION
Add a new section with a page per security advisory and the way
SpinalStack can fix it.
